### PR TITLE
Add parsing for the method for an action

### DIFF
--- a/snowcrashCLR/ActionCLR.h
+++ b/snowcrashCLR/ActionCLR.h
@@ -51,6 +51,7 @@ namespace snowcrashCLR{
         void wrap(const snowcrash::Action &action) {
             name = gcnew String(action.name.c_str());
             description = gcnew String(action.description.c_str());
+            method = gcnew String(action.method.c_str());
 
             parameters = gcnew vector<Parameter^>();
             for(snowcrash::Collection<snowcrash::Parameter>::const_iterator parameterIterator = action.parameters.begin();


### PR DESCRIPTION
Added a line to wrap the snowcrash::Action.method property in the CLR translation
