### PR TITLE
Some improvements to make it more .NET friendly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "snowcrash"]
 	path = snowcrash
-	url = git@github.com:apiaryio/snowcrash.git
+	url = https://github.com/apiaryio/snowcrash.git

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 snowcrash-dot-net-wrapper
 =========================
-
 .NET wrapper for snowcrash parser: https://github.com/apiaryio/snowcrash
+
+## Forks note
+
+This fork has been created with purpose of building it on AppVeyorn, autogenerate a nuget package and push it on the repository.
+Some modifications were necessary.
+
+1. Change snowcrash submodule url to public one instead of the old, due to some public key issues
+2. Update snowcrash to latest commits. From 0.7 we're now at 0.12, it's time to jump forward!
+
 
 # Building
 
@@ -22,5 +30,6 @@ in `Test->Test Settings->Select Test Settings File` Visual Studio menu.
 
 This project made possible in part by [Medidata Solutions](http://twitter.com/medidata)
 
+V.Chianese for the nuget package :)
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Some modifications were necessary to fit my needs. Here is in particular what I 
 - [x] Update the wrapper to the latest snowcrash version
 - [x] Change configuration for Release version of DLL (it does not compile)
 - [ ] Make it compile on AppVeyorn
-- - [ ] Make it compile on AppVeyorn
-- - [ ] Make it compile on AppVeyorn- [ ] Make it compile on AppVeyorn
+- [ ] Create a nuget package and autopush on it
+- [ ] Find a way to make it AnyCPU compatible
+- [ ] Can we do something to support Mono and Unix as well?
+- [ ] Full managed implementation ?!
 
 

--- a/README.md
+++ b/README.md
@@ -5,31 +5,13 @@ snowcrash-dot-net-wrapper
 ## Forks note
 
 This fork has been created with purpose of building it on AppVeyorn, autogenerate a nuget package and push it on the repository.
-Some modifications were necessary.
+Some modifications were necessary to fit my needs. Here is in particular what I have done and what I want to do.
 
-1. Change snowcrash submodule url to public one instead of the old, due to some public key issues
-2. Update snowcrash to latest commits. From 0.7 we're now at 0.12, it's time to jump forward!
-
-
-# Building
-
-1. Clone using GitHub client or git in Git shell:
-	* `git clone git@github.com:brutski/snowcrash-dot-net-wrapper.git`
-2. Update submodules:
-	* `cd snowcrash-dot-net-wrapper` 
-	* `git submodule update --init --recursive`
-3. Build snowcrash first:
-	* For Win32 `snowcrash\vcbuild.bat` or `snowcrash\vcbuild.bat x64` for x64 platform
-
-Now, open `snowcrash-dot-net-wrapper.sln` solution in Visual Studio and build. Make sure to use the same Win32/x64 platform for every project in solution's Configuration Manager.
-
-To execute tests make sure to specify `snowcrashCLR.tests\snowcrashCLR.runsettings` 
-in `Test->Test Settings->Select Test Settings File` Visual Studio menu.
-
-## Contributors
-
-This project made possible in part by [Medidata Solutions](http://twitter.com/medidata)
-
-V.Chianese for the nuget package :)
+- [x] Change the submodule to use public repository URL
+- [x] Update the wrapper to the latest snowcrash version
+- [x] Change configuration for Release version of DLL (it does not compile)
+- [ ] Make it compile on AppVeyorn
+- - [ ] Make it compile on AppVeyorn
+- - [ ] Make it compile on AppVeyorn- [ ] Make it compile on AppVeyorn
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ snowcrash-dot-net-wrapper
 =========================
 .NET wrapper for snowcrash parser: https://github.com/apiaryio/snowcrash
 
-## Forks note
+## Fork note
 
 This fork has been created with purpose of building it on AppVeyorn, autogenerate a nuget package and push it on the repository.
 Some modifications were necessary to fit my needs. Here is in particular what I have done and what I want to do.
@@ -12,7 +12,7 @@ Some modifications were necessary to fit my needs. Here is in particular what I 
 - [x] Change configuration for Release version of DLL (it does not compile, actually)
 - [x] Make it compile on AppVeyorn  [![Build status](https://ci.appveyor.com/api/projects/status/3d0a3hebo6u2jo1w)](https://ci.appveyor.com/project/XVincentX/snowcrash-dot-net-wrapper)
 - [ ] Find a way to make it AnyCPU compatible (side by side assembly loading, I think)
-- [x] Create a [nuget package](https://www.nuget.org/packages/Snowcrash.NET/) and autopush on it (**x86** only for now)
+- [x] Create a [nuget package](https://www.nuget.org/packages/Snowcrash.NET/) and autopush on it (**x86** only for now) [![Nuget counter](http://img.shields.io/nuget/dt/Snowcrash.NET.svg)](https://ci.appveyor.com/project/XVincentX/snowcrash-dot-net-wrapper)
 - [ ] Can we do something to support Mono and Unix as well?
 - [ ] Remove various warnings due to a lot of _deprecated_ stuff.
 - [x] Run a code analisys on the entire project (removed disposable warnings)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Some modifications were necessary to fit my needs. Here is in particular what I 
 - [x] Change the submodule to use public repository URL
 - [x] Update the wrapper to the latest snowcrash version
 - [x] Change configuration for Release version of DLL (it does not compile)
-- [ ] Make it compile on AppVeyorn
-- [ ] Create a nuget package and autopush on it
+- [ ] Make it compile on AppVeyorn  [![Build status](https://ci.appveyor.com/api/projects/status/3d0a3hebo6u2jo1w)](https://ci.appveyor.com/project/XVincentX/snowcrash-dot-net-wrapper)
 - [ ] Find a way to make it AnyCPU compatible
+- [ ] Create a nuget package and autopush on it
 - [ ] Can we do something to support Mono and Unix as well?
 - [ ] Full managed implementation ?!
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ Some modifications were necessary to fit my needs. Here is in particular what I 
 
 - [x] Change the submodule to use public repository URL
 - [x] Update the wrapper to the latest snowcrash version
-- [x] Change configuration for Release version of DLL (it does not compile)
-- [ ] Make it compile on AppVeyorn  [![Build status](https://ci.appveyor.com/api/projects/status/3d0a3hebo6u2jo1w)](https://ci.appveyor.com/project/XVincentX/snowcrash-dot-net-wrapper)
-- [ ] Find a way to make it AnyCPU compatible
-- [ ] Create a nuget package and autopush on it
+- [x] Change configuration for Release version of DLL (it does not compile, actually)
+- [x] Make it compile on AppVeyorn  [![Build status](https://ci.appveyor.com/api/projects/status/3d0a3hebo6u2jo1w)](https://ci.appveyor.com/project/XVincentX/snowcrash-dot-net-wrapper)
+- [ ] Find a way to make it AnyCPU compatible (side by side assembly loading, I think)
+- [x] Create a nuget package and autopush on it (**x86** only for now)
 - [ ] Can we do something to support Mono and Unix as well?
+- [ ] Remove various warnings due to a lot of _deprecated_ stuff.
+- [x] Run a code analisys on the entire project (removed disposable warnings)
 - [ ] Full managed implementation ?!
 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Some modifications were necessary to fit my needs. Here is in particular what I 
 - [x] Change configuration for Release version of DLL (it does not compile, actually)
 - [x] Make it compile on AppVeyorn  [![Build status](https://ci.appveyor.com/api/projects/status/3d0a3hebo6u2jo1w)](https://ci.appveyor.com/project/XVincentX/snowcrash-dot-net-wrapper)
 - [ ] Find a way to make it AnyCPU compatible (side by side assembly loading, I think)
-- [x] Create a nuget package and autopush on it (**x86** only for now)
+- [x] Create a [nuget package](https://www.nuget.org/packages/Snowcrash.NET/) and autopush on it (**x86** only for now)
 - [ ] Can we do something to support Mono and Unix as well?
 - [ ] Remove various warnings due to a lot of _deprecated_ stuff.
 - [x] Run a code analisys on the entire project (removed disposable warnings)

--- a/Snowcrash.NET.nuspec
+++ b/Snowcrash.NET.nuspec
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Snowcrash.NET</id>
         <version>1.0.0</version>
@@ -10,8 +10,11 @@
         <iconUrl>https://camo.githubusercontent.com/a38e9423fc512f02a5d1e1509c9fce68036d414f/68747470733a2f2f7261772e6769746875622e636f6d2f617069617279696f2f6170692d626c75657072696e742f6d61737465722f6173736574732f6c6f676f5f617069626c75657072696e742e706e67</iconUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <description>Snow Crash is the reference API Blueprint parser built on top of the Sundown Markdown parser.</description>
+        <releaseNotes>This version is from release x32 compiled binaries. There is not x64 support for now. I will plan to add it as soon as possible.</releaseNotes>
     </metadata>
     <files>
-        <file src="lib\net\_._" target="lib\net\_._" />
+        <file src="Release\lib\libsnowcrash.lib" target="lib\net\lib\libsnowcrash.lib" />
+        <file src="Release\lib\sundown.lib" target="lib\net\lib\sundown.lib" />
+        <file src="Release\snowcrashCLR.dll" target="lib\net\snowcrashCLR.dll" />
     </files>
 </package>

--- a/Snowcrash.NET.nuspec
+++ b/Snowcrash.NET.nuspec
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Snowcrash.NET</id>
+        <version>1.0.0</version>
+        <title>Snowcrash.net</title>
+        <authors>v.chianese</authors>
+        <licenseUrl>https://raw.githubusercontent.com/apiaryio/snowcrash/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/XVincentX/snowcrash-dot-net-wrapper</projectUrl>
+        <iconUrl>https://camo.githubusercontent.com/a38e9423fc512f02a5d1e1509c9fce68036d414f/68747470733a2f2f7261772e6769746875622e636f6d2f617069617279696f2f6170692d626c75657072696e742f6d61737465722f6173736574732f6c6f676f5f617069626c75657072696e742e706e67</iconUrl>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <description>Snow Crash is the reference API Blueprint parser built on top of the Sundown Markdown parser.</description>
+    </metadata>
+    <files>
+        <file src="lib\net\_._" target="lib\net\_._" />
+    </files>
+</package>

--- a/snowcrash-dot-net-wrapper.sln
+++ b/snowcrash-dot-net-wrapper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30324.0
+VisualStudioVersion = 12.0.30501.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "snowcrashCLR", "snowcrashCLR\snowcrashCLR.vcxproj", "{370FCD43-79AC-46A8-8E3C-135A1D5E4031}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -30,17 +30,20 @@ Global
 		{370FCD43-79AC-46A8-8E3C-135A1D5E4031}.Debug|x64.ActiveCfg = Debug|x64
 		{370FCD43-79AC-46A8-8E3C-135A1D5E4031}.Debug|x64.Build.0 = Debug|x64
 		{370FCD43-79AC-46A8-8E3C-135A1D5E4031}.Release|Win32.ActiveCfg = Release|Win32
+		{370FCD43-79AC-46A8-8E3C-135A1D5E4031}.Release|Win32.Build.0 = Release|Win32
 		{370FCD43-79AC-46A8-8E3C-135A1D5E4031}.Release|x64.ActiveCfg = Release|x64
 		{370FCD43-79AC-46A8-8E3C-135A1D5E4031}.Release|x64.Build.0 = Release|x64
 		{46F47322-2B8C-78A4-49D9-7BA2AE17D987}.Debug|Win32.ActiveCfg = Debug|Win32
 		{46F47322-2B8C-78A4-49D9-7BA2AE17D987}.Debug|Win32.Build.0 = Debug|Win32
 		{46F47322-2B8C-78A4-49D9-7BA2AE17D987}.Debug|x64.ActiveCfg = Debug|Win32
+		{46F47322-2B8C-78A4-49D9-7BA2AE17D987}.Debug|x64.Build.0 = Debug|Win32
 		{46F47322-2B8C-78A4-49D9-7BA2AE17D987}.Release|Win32.ActiveCfg = Release|Win32
 		{46F47322-2B8C-78A4-49D9-7BA2AE17D987}.Release|Win32.Build.0 = Release|Win32
 		{46F47322-2B8C-78A4-49D9-7BA2AE17D987}.Release|x64.ActiveCfg = Release|Win32
 		{C9CFC6CD-F496-5978-26F9-87FD401FCFB1}.Debug|Win32.ActiveCfg = Debug|Win32
 		{C9CFC6CD-F496-5978-26F9-87FD401FCFB1}.Debug|Win32.Build.0 = Debug|Win32
 		{C9CFC6CD-F496-5978-26F9-87FD401FCFB1}.Debug|x64.ActiveCfg = Debug|Win32
+		{C9CFC6CD-F496-5978-26F9-87FD401FCFB1}.Debug|x64.Build.0 = Debug|Win32
 		{C9CFC6CD-F496-5978-26F9-87FD401FCFB1}.Release|Win32.ActiveCfg = Release|Win32
 		{C9CFC6CD-F496-5978-26F9-87FD401FCFB1}.Release|Win32.Build.0 = Release|Win32
 		{C9CFC6CD-F496-5978-26F9-87FD401FCFB1}.Release|x64.ActiveCfg = Release|Win32

--- a/snowcrashCLR/ActionCLR.h
+++ b/snowcrashCLR/ActionCLR.h
@@ -14,7 +14,7 @@ namespace snowcrashCLR{
     /**
 	 *	CLR Wrapper for snowcrash::Action.
 	 */
-    public ref class Action {
+	public ref class Action {
     private:
         vector<Parameter^> ^parameters;
         vector<Header^> ^headers;
@@ -47,6 +47,13 @@ namespace snowcrashCLR{
         ICollection<TransactionExample^> ^GetTransactionExamplesCs() {
             return examples;
         }
+
+		~Action()
+		{
+			delete parameters;
+			delete headers;
+			delete examples;
+		}
 
         void wrap(const snowcrash::Action &action) {
             name = gcnew String(action.name.c_str());
@@ -83,6 +90,7 @@ namespace snowcrashCLR{
 				example->wrap(*examplesIterator);
                 examples->push_back(example);
 			}
+
         }
     };
 }

--- a/snowcrashCLR/BlueprintCLR.h
+++ b/snowcrashCLR/BlueprintCLR.h
@@ -64,6 +64,12 @@ namespace snowcrashCLR {
 			return resourceGroups;
 		}
 
+		~Blueprint()
+		{
+			delete metadata;
+			delete resourceGroups;
+		}
+
 		/**
 		 *	\brief	Wrap Snow Crash Blueprint.
 		 *	\param	blueprint	A Snow Crash blueprint to wrap.

--- a/snowcrashCLR/ParameterCLR.h
+++ b/snowcrashCLR/ParameterCLR.h
@@ -32,6 +32,11 @@ namespace snowcrashCLR{
             return values;
         }
 
+		~Parameter()
+		{
+			delete values;
+		}
+
         void wrap(const snowcrash::Parameter &parameter) {
             name = gcnew String(parameter.name.c_str());
             description = gcnew String(parameter.description.c_str());

--- a/snowcrashCLR/PayloadCLR.h
+++ b/snowcrashCLR/PayloadCLR.h
@@ -39,6 +39,12 @@ namespace snowcrashCLR{
         ICollection<Header^> ^GetHeadersCs() {
             return headers;
         }
+
+		~Payload()
+		{
+			delete headers;
+			delete parameters;
+		}
         
         void wrap(const snowcrash::Payload &payload) {
             name = gcnew String(payload.name.c_str());

--- a/snowcrashCLR/ResourceCLR.h
+++ b/snowcrashCLR/ResourceCLR.h
@@ -50,6 +50,13 @@ namespace snowcrashCLR{
             return actions;
         }
 
+		~Resource()
+		{
+			delete parameters;
+			delete headers;
+			delete actions;
+		}
+
         void wrap(const snowcrash::Resource &resource) {
             name = gcnew String(resource.name.c_str());
             description = gcnew String(resource.description.c_str());

--- a/snowcrashCLR/ResourceGroupCLR.h
+++ b/snowcrashCLR/ResourceGroupCLR.h
@@ -29,6 +29,11 @@ namespace snowcrashCLR{
             return resources;
         }
 
+		~ResourceGroup()
+		{
+			delete resources;
+		}
+
 		void wrap(const snowcrash::ResourceGroup &group)
 		{
 			// Wrap Group Name

--- a/snowcrashCLR/SourceAnnotationCLR.h
+++ b/snowcrashCLR/SourceAnnotationCLR.h
@@ -30,6 +30,11 @@ namespace snowcrashCLR {
             return location;
         }
 
+		~SourceAnnotation()
+		{
+			delete location;
+		}
+
         void wrap(const snowcrash::SourceAnnotation &source) {
             message = gcnew String(source.message.c_str());
             code = source.code;
@@ -83,6 +88,11 @@ namespace snowcrashCLR {
         ICollection<Warning^> ^GetWarningsCs() {
             return warnings;
         }
+
+		~Result()
+		{
+			delete warnings;
+		}
 
         void wrap(const snowcrash::Result &result){
             error = gcnew Error();

--- a/snowcrashCLR/TransactionExampleCLR.h
+++ b/snowcrashCLR/TransactionExampleCLR.h
@@ -38,6 +38,12 @@ namespace snowcrashCLR {
             return responses;
         }
 
+		~TransactionExample()
+		{
+			delete responses;
+			delete requests;
+		}
+
         void wrap(const snowcrash::TransactionExample &transactionExample) {
             name = gcnew String(transactionExample.name.c_str());
             description = gcnew String(transactionExample.description.c_str());

--- a/snowcrashCLR/snowcrashCLR.vcxproj
+++ b/snowcrashCLR/snowcrashCLR.vcxproj
@@ -42,7 +42,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v110</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/snowcrashCLR/snowcrashCLR.vcxproj
+++ b/snowcrashCLR/snowcrashCLR.vcxproj
@@ -119,7 +119,8 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies />
+      <AdditionalDependencies>libsnowcrash.lib;sundown.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\Release\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -132,7 +133,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>libsnowcrash.lib;sundown.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\.\snowcrash\build\Release\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\Release\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
The "list" of what I have done and what I'm going to do is here:
- [x] Change the submodule to use public repository URL
- [x] Update the wrapper to the latest snowcrash version
- [x] Change configuration for Release version of DLL (it does not compile, actually)
- [x] Make it compile on AppVeyorn  [![Build status](https://ci.appveyor.com/api/projects/status/3d0a3hebo6u2jo1w)](https://ci.appveyor.com/project/XVincentX/snowcrash-dot-net-wrapper)
- [x] Create a [nuget package](https://www.nuget.org/packages/Snowcrash.NET/) and autopush on it (**x86** only for now)
  [x] Run a code analisys on the entire project (removed disposable warnings)
